### PR TITLE
Added a new `list` command to display installed PHP versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # PHP Switcher
 
-A simple CLI tool to manage multiple PHP versions on macOS using Homebrew.
-(Currently only supports macOS with Homebrew. Linux/Windows support is planned).
+A simple CLI tool to manage multiple PHP versions on macOS and Linux.
 
 ## Features
 
-*   Install specific PHP versions (via Homebrew).
-*   Switch the active linked PHP version (via Homebrew).
+*   Install specific PHP versions (via Homebrew for macOS, or APT for Linux).
+*   Switch the active PHP version.
+*   List all installed PHP versions.
+*   Auto-detect required version from `composer.json`.
 
 ## Prerequisites
 
-*   **macOS:** The current version only supports macOS.
-*   **Homebrew:** Required for installing and managing PHP versions. Ensure it's installed: [https://brew.sh/](https://brew.sh/)
+*   **macOS:** Requires **Homebrew** for installing and managing PHP versions.
+*   **Linux (Debian/Ubuntu):** Requires `apt` and the `software-properties-common` package. `sudo` is required for installing and switching versions.
 
 ## Installation
 
@@ -32,7 +33,18 @@ phpswitcher help
 
 ## Usage
 
-*(Currently supports macOS/Homebrew only)*
+**List installed PHP versions:**
+
+Shows all available PHP versions and highlights the one that is currently active.
+
+```bash
+phpswitcher list
+# Example Output:
+#
+# Installed PHP Versions (via Homebrew):
+#    7.4
+#  * 8.1 (active)
+```
 
 **Install a PHP version:**
 

--- a/bin/phpswitcher
+++ b/bin/phpswitcher
@@ -57,6 +57,84 @@ detect_os() {
 
 # --- Command Implementations ---
 
+command_list_macos() {
+    echo_message "Installed PHP Versions (via Homebrew):"
+
+    local installed_php_versions
+    installed_php_versions=$(brew list --formula | grep '^php@' || true)
+
+    if [ -z "$installed_php_versions" ]; then
+        echo "No PHP versions found."
+        return
+    fi
+
+    # Determine active version by checking the symlink for 'php'
+    local active_version=""
+    local php_link
+    # Follow the symlink to find out which version is active
+    php_link=$(readlink "$(brew --prefix)/bin/php" 2>/dev/null || echo "")
+    if [[ "$php_link" =~ php@([0-9]+\.[0-9]+) ]]; then
+        active_version="${BASH_REMATCH[1]}"
+    fi
+
+    for formula in $installed_php_versions; do
+        local version=${formula#php@}
+        if [ "$version" == "$active_version" ]; then
+            echo " * $version (active)"
+        else
+            echo "   $version"
+        fi
+    done
+}
+
+command_list_linux() {
+    echo_message "Installed PHP Versions (via update-alternatives):"
+
+    if ! command -v update-alternatives >/dev/null; then
+        echo_error "The 'update-alternatives' command is not available on this system."
+        return
+    fi
+
+    local alternatives
+    alternatives=$(update-alternatives --list php 2>/dev/null || echo "")
+
+    if [ -z "$alternatives" ]; then
+        echo "No PHP versions found configured with update-alternatives."
+        return
+    fi
+
+    # Get the canonical path of the active binary (e.g., /usr/bin/php8.1)
+    local active_php_path
+    active_php_path=$(readlink -f /etc/alternatives/php 2>/dev/null || echo "")
+
+    (
+        # Use a subshell to read each line to avoid issues in loops
+        echo "$alternatives" | while IFS= read -r line; do
+            local version
+            # Extract X.Y version from a path like /usr/bin/phpX.Y
+            if [[ "$line" =~ php([0-9]+\.[0-9]+)$ ]]; then
+                version="${BASH_REMATCH[1]}"
+                if [ "$line" == "$active_php_path" ]; then
+                    echo " * $version (active)"
+                else
+                    echo "   $version"
+                fi
+            fi
+        done
+    )
+}
+
+command_list() {
+    if [ "$OS" = "macos" ]; then
+        command_list_macos
+    elif [ "$OS" = "linux" ]; then
+        command_list_linux
+    else
+        echo_error "The 'list' command is not supported on this OS."
+        exit 1
+    fi
+}
+
 command_version() {
     local version_file="$PHPSWITCHER_DIR/VERSION"
     if [ -f "$version_file" ]; then
@@ -411,6 +489,7 @@ command_help() {
     echo "                       If <version> is omitted, it attempts to detect from composer.json."
     echo "  use [<version>]      Switch the active PHP version."
     echo "                       If <version> is omitted, it attempts to detect from composer.json."
+    echo "  list                 List all installed PHP versions and show the active one."
     echo "  self-update          Update phpswitcher to the latest version."
     echo "  version              Show the currently installed version of phpswitcher."
     echo "  help                 Show this help message."
@@ -443,6 +522,9 @@ main() {
             ;;
         install)
             command_install "$@"
+            ;;
+        list)
+            command_list
             ;;
         self-update)
             command_self_update "$@"


### PR DESCRIPTION
This new command for the `phpswitcher` tool provides you with a list of all installed PHP versions, highlighting the currently active one. This is a common feature in version management tools and improves the usability of `phpswitcher`.

The implementation includes:
- A `command_list` function with support for both macOS (Homebrew) and Linux (update-alternatives).
- Integration of the `list` command into the main script.
- Updated documentation in `README.md` to reflect the new command and to clarify existing Linux support.