### PR TITLE
feat: add Homebrew and Packagist publishing support

### DIFF
--- a/Formula/phpswitcher.rb
+++ b/Formula/phpswitcher.rb
@@ -1,31 +1,35 @@
 class Phpswitcher < Formula
-  desc "CLI tool to manage and switch between multiple PHP versions"
+  desc "Manage and switch between multiple PHP versions"
   homepage "https://github.com/rawdreeg/phpswitcher"
   url "https://github.com/rawdreeg/phpswitcher/releases/download/v0.4.0-beta.1/phpswitcher.tar.gz"
+  version "0.4.0-beta.1"
   sha256 "23ed0e3f960fd762cb137dcfe9d4afce973698ea5ca7bef8a45e3885b6a2a91c"
   license "MIT"
+  head "https://github.com/rawdreeg/phpswitcher.git", branch: "main"
+
+  depends_on "curl" => :recommended
 
   def install
     bin.install "bin/phpswitcher"
-    share.install "phpswitcher-init.sh"
-    share.install "phpswitcher-init.fish"
+    pkgshare.install "phpswitcher-init.sh"
+    pkgshare.install "phpswitcher-init.fish"
     bash_completion.install "phpswitcher-completion.sh" => "phpswitcher"
     fish_completion.install "phpswitcher-completion.fish" => "phpswitcher.fish"
   end
 
   def caveats
     <<~EOS
-      To enable auto-switching, add the following to your shell profile:
+      To enable automatic PHP version switching, add to your shell profile:
 
-      For Bash (~/.bashrc) or Zsh (~/.zshrc):
-        source "#{opt_share}/phpswitcher-init.sh"
+      Bash (~/.bashrc) or Zsh (~/.zshrc):
+        source "#{opt_pkgshare}/phpswitcher-init.sh"
 
-      For Fish (~/.config/fish/config.fish):
-        source "#{opt_share}/phpswitcher-init.fish"
+      Fish (~/.config/fish/config.fish):
+        source "#{opt_pkgshare}/phpswitcher-init.fish"
     EOS
   end
 
   test do
-    assert_match "phpswitcher", shell_output("#{bin}/phpswitcher version")
+    assert_match version.to_s, shell_output("#{bin}/phpswitcher version")
   end
 end

--- a/Formula/phpswitcher.rb
+++ b/Formula/phpswitcher.rb
@@ -1,0 +1,31 @@
+class Phpswitcher < Formula
+  desc "CLI tool to manage and switch between multiple PHP versions"
+  homepage "https://github.com/rawdreeg/phpswitcher"
+  url "https://github.com/rawdreeg/phpswitcher/releases/download/v0.4.0-beta.1/phpswitcher.tar.gz"
+  sha256 "23ed0e3f960fd762cb137dcfe9d4afce973698ea5ca7bef8a45e3885b6a2a91c"
+  license "MIT"
+
+  def install
+    bin.install "bin/phpswitcher"
+    share.install "phpswitcher-init.sh"
+    share.install "phpswitcher-init.fish"
+    bash_completion.install "phpswitcher-completion.sh" => "phpswitcher"
+    fish_completion.install "phpswitcher-completion.fish" => "phpswitcher.fish"
+  end
+
+  def caveats
+    <<~EOS
+      To enable auto-switching, add the following to your shell profile:
+
+      For Bash (~/.bashrc) or Zsh (~/.zshrc):
+        source "#{opt_share}/phpswitcher-init.sh"
+
+      For Fish (~/.config/fish/config.fish):
+        source "#{opt_share}/phpswitcher-init.fish"
+    EOS
+  end
+
+  test do
+    assert_match "phpswitcher", shell_output("#{bin}/phpswitcher version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -24,14 +24,39 @@ A simple CLI tool to manage multiple PHP versions on macOS and Linux.
 
 ## Installation
 
-Run the following command in your terminal to download and execute the installation script:
+### Homebrew (macOS/Linux)
 
 ```bash
-# Ensure you have curl installed
+brew install rawdreeg/phpswitcher/phpswitcher
+```
+
+After installation, add the shell integration to your profile:
+
+```bash
+# Bash (~/.bashrc) or Zsh (~/.zshrc):
+source "$(brew --prefix)/share/phpswitcher-init.sh"
+
+# Fish (~/.config/fish/config.fish):
+source "$(brew --prefix)/share/phpswitcher-init.fish"
+```
+
+### Composer (global)
+
+```bash
+composer global require rawdreeg/phpswitcher
+```
+
+Make sure your Composer global `bin` directory is in your `PATH` (typically `~/.composer/vendor/bin` or `~/.config/composer/vendor/bin`).
+
+### Install script
+
+```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/rawdreeg/phpswitcher/main/install.sh)"
 ```
 
 This will install `phpswitcher` to `$HOME/.phpswitcher` and add it to your shell's profile file (e.g., `.zshrc`, `.bashrc`).
+
+---
 
 After installation, open a **new terminal session** or run `source ~/.zshrc` (or the equivalent for your shell) and verify with:
 

--- a/README.md
+++ b/README.md
@@ -24,41 +24,25 @@ A simple CLI tool to manage multiple PHP versions on macOS and Linux.
 
 ## Installation
 
-### Homebrew (macOS/Linux)
+### Homebrew (macOS)
 
 ```bash
 brew install rawdreeg/phpswitcher/phpswitcher
 ```
 
-After installation, add the shell integration to your profile:
-
-```bash
-# Bash (~/.bashrc) or Zsh (~/.zshrc):
-source "$(brew --prefix)/share/phpswitcher-init.sh"
-
-# Fish (~/.config/fish/config.fish):
-source "$(brew --prefix)/share/phpswitcher-init.fish"
-```
-
-### Composer (global)
+### Composer
 
 ```bash
 composer global require rawdreeg/phpswitcher
 ```
 
-Make sure your Composer global `bin` directory is in your `PATH` (typically `~/.composer/vendor/bin` or `~/.config/composer/vendor/bin`).
-
-### Install script
+### Install script (macOS & Linux)
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/rawdreeg/phpswitcher/main/install.sh)"
 ```
 
-This will install `phpswitcher` to `$HOME/.phpswitcher` and add it to your shell's profile file (e.g., `.zshrc`, `.bashrc`).
-
----
-
-After installation, open a **new terminal session** or run `source ~/.zshrc` (or the equivalent for your shell) and verify with:
+After installing, restart your terminal and verify with:
 
 ```bash
 phpswitcher help

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,33 @@
+{
+    "name": "rawdreeg/phpswitcher",
+    "description": "CLI tool to manage and switch between multiple PHP versions on macOS and Linux",
+    "type": "library",
+    "license": "MIT",
+    "keywords": [
+        "php",
+        "version-manager",
+        "php-switcher",
+        "cli",
+        "homebrew",
+        "apt"
+    ],
+    "authors": [
+        {
+            "name": "Rodrigue",
+            "homepage": "https://github.com/rawdreeg"
+        }
+    ],
+    "homepage": "https://github.com/rawdreeg/phpswitcher",
+    "support": {
+        "issues": "https://github.com/rawdreeg/phpswitcher/issues",
+        "source": "https://github.com/rawdreeg/phpswitcher"
+    },
+    "bin": [
+        "bin/phpswitcher"
+    ],
+    "require": {},
+    "config": {
+        "preferred-install": "dist",
+        "sort-packages": true
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,9 @@
 {
     "name": "rawdreeg/phpswitcher",
-    "description": "CLI tool to manage and switch between multiple PHP versions on macOS and Linux",
-    "type": "library",
+    "description": "CLI tool to manage and switch between multiple PHP versions",
+    "type": "project",
     "license": "MIT",
-    "keywords": [
-        "php",
-        "version-manager",
-        "php-switcher",
-        "cli",
-        "homebrew",
-        "apt"
-    ],
+    "keywords": ["php", "version-manager", "cli"],
     "authors": [
         {
             "name": "Rodrigue",
@@ -22,12 +15,5 @@
         "issues": "https://github.com/rawdreeg/phpswitcher/issues",
         "source": "https://github.com/rawdreeg/phpswitcher"
     },
-    "bin": [
-        "bin/phpswitcher"
-    ],
-    "require": {},
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true
-    }
+    "bin": ["bin/phpswitcher"]
 }


### PR DESCRIPTION
## Summary

Adds Homebrew and Packagist distribution support:

- `Formula/phpswitcher.rb` — Homebrew formula for `brew install rawdreeg/phpswitcher/phpswitcher`
- `composer.json` — Packagist package for `composer global require rawdreeg/phpswitcher`
- Updated README with all three installation methods

## Setup needed after merge

1. **Homebrew tap**: Create a public repo `rawdreeg/homebrew-phpswitcher` and copy `Formula/phpswitcher.rb` into `Formula/`
2. **Packagist**: Submit `https://github.com/rawdreeg/phpswitcher` at packagist.org/packages/submit
3. **Auto-update (optional)**: Add a `HOMEBREW_TAP_TOKEN` secret and a release-triggered workflow to push formula updates to the tap

## Test plan

- [ ] `brew install --build-from-source Formula/phpswitcher.rb`
- [ ] `composer global require rawdreeg/phpswitcher`
- [ ] `phpswitcher version` works after each install method

https://claude.ai/code/session_01St4nyeLLXnBcxpXis7qyoH